### PR TITLE
Replace OrderedDict in multi-launch middleware.

### DIFF
--- a/django_auth_lti/middleware.py
+++ b/django_auth_lti/middleware.py
@@ -1,12 +1,6 @@
 import logging
 import json
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    # python 2.6 or earlier, use backport: pip install ordereddict
-    from ordereddict import OrderedDict
-
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings

--- a/django_auth_lti/middleware_patched.py
+++ b/django_auth_lti/middleware_patched.py
@@ -1,8 +1,6 @@
 import logging
-import json
-import django_auth_lti.patch_reverse
 
-from collections import OrderedDict
+import django_auth_lti.patch_reverse
 
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
@@ -70,7 +68,7 @@ class MultiLTILaunchAuthMiddleware(MiddlewareMixin):
                 request.user = user
                 with Timer() as t:
                     auth.login(request, user)
-    
+
                 logger.debug('login() took %s s' % t.secs)
 
                 resource_link_id = request.POST.get('resource_link_id', None)
@@ -122,19 +120,32 @@ class MultiLTILaunchAuthMiddleware(MiddlewareMixin):
                     lti_launch['roles'] += filter(None, custom_roles)  # Filter out any empty roles
 
                 lti_launches = request.session.get('LTI_LAUNCH')
-                if not lti_launches or not isinstance(lti_launches, OrderedDict):
-                    lti_launches = OrderedDict()
+                if not lti_launches:
+                    lti_launches = {}
                     request.session['LTI_LAUNCH'] = lti_launches
+
+                # Count the LTI launches and index each one so they can be ordered.
+                # We are not using an OrderedDict because django serializes using JSON by default, which would
+                # require a custom serializer to ensure objects are deserialized appropriately
+                lti_launch_count = request.session.get('LTI_LAUNCH_COUNT', 0) + 1
+                request.session['LTI_LAUNCH_COUNT'] = lti_launch_count
+                lti_launch['_order'] = lti_launch_count
 
                 # Limit the number of LTI launches stored in the session
                 max_launches = getattr(settings, 'LTI_AUTH_MAX_LAUNCHES', 10)
                 logger.info("LTI launch count %s [max=%s]" % (len(lti_launches.keys()), max_launches))
                 if len(lti_launches.keys()) >= max_launches:
-                    invalidated_launch = lti_launches.popitem(last=False)
-                    logger.info("LTI launch invalidated: %s", json.dumps(invalidated_launch, indent=4))
+                    # If the current resource is being re-launched, then we should just invalidate the old launch,
+                    # otherwise we should evict the oldest launch (FIFO).
+                    remove_resource_link_id = resource_link_id
+                    if remove_resource_link_id not in lti_launches:
+                        ordered_launches = sorted(lti_launches.items(), key=lambda item: item[1].get('_order', -1))
+                        remove_resource_link_id = ordered_launches[0][0]
+                    invalidated_launch = lti_launches.pop(remove_resource_link_id)
+                    logger.info("LTI launch invalidated: %s", invalidated_launch)
 
                 lti_launches[resource_link_id] = lti_launch
-                logger.info("LTI launch added to session: %s", json.dumps(lti_launch, indent=4))
+                logger.info("LTI launch added to session: %s", lti_launch)
             else:
                 # User could not be authenticated!
                 logger.warning('user could not be authenticated via LTI params; let the request continue in case another auth plugin is configured')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-auth-lti',
-    version='1.3.0',
+    version='1.3.1',
     packages=['django_auth_lti'],
     include_package_data=True,
     license='TBD License',  # example license


### PR DESCRIPTION
This PR fixes an issue with the multi-launch middleware. The issue is that the middleware is not maintaining multiple launches in the session, keyed by `resource_link_id`. Only the most recent launch is being saved in the session.

The problem stems from the fact that the launch data is being stored in an `OrderedDict`, which does not play well with the [default django serializer](https://docs.djangoproject.com/en/2.1/topics/http/sessions/#session-serialization). The default serializer uses JSON as the format for persisting data to the filesystem/database/redis, so when the data is deserialized on subsequent requests, the launch dict becomes a standard python `dict` rather than an `OrderedDict`. As a result, the code fails to detect the previous launches, and re-initializes the launch dict every time.

Rather than use an `OrderedDict` to preserve the order of the launches (and configure a custom session serializer to handle it appropriately), this PR proposes to use a `dict` in combination with an index value assigned to each launch dict that can be sorted on, if/when it becomes necessary to invalidate launches. 

Note: tested this in development environment and seems to work as expected.

@joshuagetega Thoughts?